### PR TITLE
Cross now disappears when correct input is given

### DIFF
--- a/newdle_frontend.js
+++ b/newdle_frontend.js
@@ -60,6 +60,7 @@ function checkGuess() {
     const PLAYER_GUESS = GUESS_BOX.value.toLowerCase().trim();
 
     if (headlineArrayLower.includes(PLAYER_GUESS)){
+        RESULT_PTAG.innerText = ""
         wordIndexes = getWordIndexes(headlineArrayLower,PLAYER_GUESS)
         var updatedHeadline = document.getElementById("presented_headline").innerText.split(" ")
         for (i of wordIndexes){

--- a/newdle_style.css
+++ b/newdle_style.css
@@ -170,7 +170,7 @@ body {
     min-width: 170px;
   }
 }
-}
+
 #share_button{
     visibility: hidden;
 }


### PR DESCRIPTION
The cross is replaced with an empty string when correct input is given. This seems to mess with the share button, but that button will only appear upon completion of the game, and so there will not be a cross and share button simultaneously.