### PR TITLE
A headline now shows when there is no incoming headline

### DIFF
--- a/newsle_frontend.js
+++ b/newsle_frontend.js
@@ -29,10 +29,18 @@ function instructionsDisappear(){
 
  
 fetch('https://newsle-backend-c6c785fcf3f1.herokuapp.com/Game_info')
-.then(api_response => {return api_response.json()})
+.then(api_response => api_response.json())
+.catch(() => {
+    // Fallback JSON in case of a network error
+    return { 
+        "headline": "Earth invaded by Martians", 
+        "scrambled_headline": "thEar deidvna by asrntaiM" 
+    };
+})
 .then(json_response => {
-    getHeadlines(json_response)
+    getHeadlines(json_response);
 });
+
 
 // Main function
 
@@ -48,7 +56,9 @@ function onSubmit(){
 
 function getHeadlines(headlines_json){
 
-    headlines_json.replace('‘', "'").replace('’', "'").replace('“',"\"").replace('”',"\"")
+    for (headlines in headlines_json){
+        headlines.replace('‘', "'").replace('’', "'").replace('“',"\"").replace('”',"\"")
+    }
     
     document.getElementById("presented_headline").innerText = headlines_json.scrambled_headline
     headlineArray = headlines_json.headline.split(" ")


### PR DESCRIPTION
Added the lines:

`.catch(() => {
    // Fallback JSON in case of a network error
    return { 
        "headline": "Earth invaded by Martians", 
        "scrambled_headline": "thEar deidvna by asrntaiM" 
    };
})`

to automatically add a headline ( a totally true one ) when the backend isn't running